### PR TITLE
Send Lua output to Menu Console

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -50,11 +50,11 @@ RegisterNetEvent('xv-dev:client:UpdateOutput', function(output, eventType)
 end)
 
 RegisterNetEvent('xv-dev:client:ExecLua', function(code)
-    local func, err = load(code)
+    local func, err = load('return ' .. code, '@xv-dev')
     if func then
-        local status, result = pcall(func)
+        local status, result = pcall(func, '@xv-dev')
         if status then
-            output = "Executed"
+            output = tostring(result)
         else
             output = "Error: " .. (result or "Unknown")
         end
@@ -70,4 +70,3 @@ RegisterNUICallback('ExecuteLua', function(data, cb)
     TriggerServerEvent('xv-dev:server:verifyExec', code, eventType)
     cb(1)
 end)
-


### PR DESCRIPTION
Sends the output of the Quick Function or Lua exe to the console inside of the menu.

Example:
![image](https://user-images.githubusercontent.com/66404074/204058549-dca17d15-989b-49d7-a5a1-cddb130643a0.png)
